### PR TITLE
Make User first_name/last_name optional

### DIFF
--- a/src/user_management/operations/update_user.rs
+++ b/src/user_management/operations/update_user.rs
@@ -98,7 +98,10 @@ mod test {
             .build();
 
         let _mock = server
-            .mock("PUT", "/user_management/users/user_01EHZNVPK3SFK441A1RGBFSHRT")
+            .mock(
+                "PUT",
+                "/user_management/users/user_01EHZNVPK3SFK441A1RGBFSHRT",
+            )
             .match_header("Authorization", "Bearer sk_example_123456789")
             .with_status(200)
             .with_body(
@@ -134,6 +137,6 @@ mod test {
             .await
             .unwrap();
 
-        assert_eq!(user.last_name, "Smith");
+        assert_eq!(user.last_name.as_deref(), Some("Smith"));
     }
 }

--- a/src/user_management/types/user.rs
+++ b/src/user_management/types/user.rs
@@ -36,10 +36,10 @@ pub struct User {
     pub email: String,
 
     /// The first name of the user.
-    pub first_name: String,
+    pub first_name: Option<String>,
 
     /// The last name of the user.
-    pub last_name: String,
+    pub last_name: Option<String>,
 
     /// Whether the user's email has been verified.
     pub email_verified: bool,
@@ -59,4 +59,36 @@ pub struct User {
     /// The timestamps for the user.
     #[serde(flatten)]
     pub timestamps: Timestamps,
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::User;
+
+    #[test]
+    fn it_deserializes_a_user_with_null_names() {
+        let user: User = serde_json::from_str(
+            &json!({
+                "object": "user",
+                "id": "user_01EHZNVPK3SFK441A1RGBFSHRT",
+                "email": "user@example.com",
+                "email_verified": true,
+                "first_name": null,
+                "last_name": null,
+                "profile_picture_url": null,
+                "last_sign_in_at": "2021-06-25T19:07:33.155Z",
+                "external_id": null,
+                "metadata": {},
+                "created_at": "2021-06-25T19:07:33.155Z",
+                "updated_at": "2021-06-25T19:07:33.155Z"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(user.first_name, None);
+        assert_eq!(user.last_name, None);
+    }
 }


### PR DESCRIPTION
The WorkOS API returns null `first_name` and `last_name` for users who sign up without providing names (e.g. through AuthKit). `User` declared both as required `String`, so deserialization failed for any such user — `get_user`, `list_users`, and `get_user_by_external_id` returned a decode error instead of the user. This makes both fields `Option<String>`, matching how the SSO `Profile` and `DirectoryUser` types already model them, and adds a regression test deserializing a user with null names.
